### PR TITLE
Temp fix for morphling getting the flash modifier.

### DIFF
--- a/source/Patches/RpcHandling.cs
+++ b/source/Patches/RpcHandling.cs
@@ -596,7 +596,7 @@ namespace TownOfUs
                 Role.Gen(role, impostors, rpc);
             }
 
-            var crewmates2 = Utils.getCrewmates(infected).Where(x => !x.Is(RoleEnum.Glitch)).ToList();
+            var crewmates2 = Utils.getCrewmates(infected).Where(x => !x.Is(RoleEnum.Glitch) || !x.Is(RoleEnum.Morphling)).ToList();
             foreach (var (modifier, rpc) in CrewmateModifiers)
             {
                 //System.Console.WriteLine(modifier);


### PR DESCRIPTION
Just added morphling to the exclusion check in the LINQ query for crew members in order to give them modifiers. When morphling gets flash it is almost impossible to win much like the glitch role. I think some better logic could be employed but I just went through the code quickly to understand it and this seems like a simple addition without much rewriting.