### PR TITLE
Mayor skip glitch

### DIFF
--- a/source/Patches/CrewmateRoles/MayorMod/RegisterExtraVotes.cs
+++ b/source/Patches/CrewmateRoles/MayorMod/RegisterExtraVotes.cs
@@ -179,9 +179,9 @@ namespace TownOfUs.CrewmateRoles.MayorMod
         [HarmonyPatch(typeof(MeetingHud), nameof(MeetingHud.VotingComplete))]
         public static class VotingComplete
         {
-            public static bool Prefix(MeetingHud __instance)
+            public static void Prefix(MeetingHud __instance, bool tie)
             {
-                if (!AmongUsClient.Instance.AmHost) return true;
+                if (!AmongUsClient.Instance.AmHost) return;
                 foreach (var role in Role.GetRoles(RoleEnum.Mayor))
                 {
                     var writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId,
@@ -191,10 +191,10 @@ namespace TownOfUs.CrewmateRoles.MayorMod
                     AmongUsClient.Instance.FinishRpcImmediately(writer);
                 }
 
-                return true;
+                PluginSingleton<TownOfUs>.Instance.Log.LogMessage($"Sending tie status from param: {tie}");
             }
 
-            public static void Postfix(MeetingHud __instance)
+            public static void Postfix(MeetingHud __instance, bool tie)
             {
                 // __instance.exiledPlayer = __instance.wasTie ? null : __instance.exiledPlayer;
                 PluginSingleton<TownOfUs>.Instance.Log.LogMessage($"Exiled PlayerID = {__instance.exiledPlayer}");
@@ -202,7 +202,7 @@ namespace TownOfUs.CrewmateRoles.MayorMod
                     PluginSingleton<TownOfUs>.Instance.Log.LogMessage(
                         $"Exiled PlayerName = {__instance.exiledPlayer.PlayerName}");
 
-                PluginSingleton<TownOfUs>.Instance.Log.LogMessage($"Was a tie = {__instance.wasTie}");
+                PluginSingleton<TownOfUs>.Instance.Log.LogMessage($"Was a tie = {__instance.wasTie}, param = {tie}");
             }
         }
 

--- a/source/Patches/CrewmateRoles/SwapperMod/ShowHideButtons.cs
+++ b/source/Patches/CrewmateRoles/SwapperMod/ShowHideButtons.cs
@@ -1,7 +1,7 @@
-using System.Collections.Generic;
-using System.Linq;
 using HarmonyLib;
 using Hazel;
+using System.Collections.Generic;
+using System.Linq;
 using TownOfUs.CrewmateRoles.MayorMod;
 using TownOfUs.Extensions;
 using TownOfUs.Roles;
@@ -69,11 +69,10 @@ namespace TownOfUs.CrewmateRoles.SwapperMod
                     }
                 }
 
-
                 if (SwapVotes.Swap1 == null || SwapVotes.Swap2 == null) return true;
 
                 var writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId,
-                    (byte) CustomRPC.SetSwaps, SendOption.Reliable, -1);
+                    (byte)CustomRPC.SetSwaps, SendOption.Reliable, -1);
                 writer.Write(SwapVotes.Swap1.TargetPlayerId);
                 writer.Write(SwapVotes.Swap2.TargetPlayerId);
                 AmongUsClient.Instance.FinishRpcImmediately(writer);
@@ -95,7 +94,7 @@ namespace TownOfUs.CrewmateRoles.SwapperMod
                     var maxIdx = self.MaxPair(out var tie);
 
                     PluginSingleton<TownOfUs>.Instance.Log.LogMessage($"Meeting was a tie = {tie}");
-                    var exiled = GameData.Instance.AllPlayers.ToArray().FirstOrDefault(v => v.PlayerId == maxIdx.Key);
+                    var exiled = GameData.Instance.AllPlayers.ToArray().FirstOrDefault(v => !tie && v.PlayerId == maxIdx.Key);
                     for (var i = 0; i < __instance.playerStates.Length; i++)
                     {
                         var playerVoteArea = __instance.playerStates[i];
@@ -106,8 +105,8 @@ namespace TownOfUs.CrewmateRoles.SwapperMod
                         };
                     }
 
-                    __instance.exiledPlayer = tie ? null : exiled;
-                    __instance.wasTie = tie;
+                    //__instance.exiledPlayer = tie ? null : exiled;
+                    //__instance.wasTie = tie;
                     __instance.RpcVotingComplete(array, __instance.exiledPlayer, tie);
                 }
 

--- a/source/Patches/CustomHats/CreateHat.cs
+++ b/source/Patches/CustomHats/CreateHat.cs
@@ -9,6 +9,7 @@ namespace TownOfUs.CustomHats
     {
         private static bool modded;
 
+        // TODO Revert this once hats are properly implemented.
         public static Sprite EmptySprite = null;// TownOfUs.CreateSprite("TownOfUs.Resources.Hats.transparent.png", true);
 
         private static readonly List<HatData> _hatDatas = new List<HatData>
@@ -293,6 +294,7 @@ namespace TownOfUs.CustomHats
             public int framecount;
         }
 
+        // TODO Revert this once hats are reimplemented.
         //[HarmonyPatch(typeof(HatManager), nameof(HatManager.GetHatById))]
         public static class HatManagerPatch
         {

--- a/source/Patches/CustomHats/CreateHat.cs
+++ b/source/Patches/CustomHats/CreateHat.cs
@@ -1,6 +1,6 @@
+using HarmonyLib;
 using System;
 using System.Collections.Generic;
-using HarmonyLib;
 using UnityEngine;
 
 namespace TownOfUs.CustomHats
@@ -9,8 +9,7 @@ namespace TownOfUs.CustomHats
     {
         private static bool modded;
 
-        public static Sprite EmptySprite = TownOfUs.CreateSprite("TownOfUs.Resources.Hats.transparent.png", true);
-
+        public static Sprite EmptySprite = null;// TownOfUs.CreateSprite("TownOfUs.Resources.Hats.transparent.png", true);
 
         private static readonly List<HatData> _hatDatas = new List<HatData>
         {
@@ -77,7 +76,6 @@ namespace TownOfUs.CustomHats
                 name = "chilled", bounce = false, highUp = false, offset = new Vector2(-0.1f, 0.2f),
                 author = "Nassegris"
             },
-
 
             new HatData
             {
@@ -168,7 +166,6 @@ namespace TownOfUs.CustomHats
                 name = "falcone", bounce = true, highUp = false, offset = new Vector2(-0.1f, 0.4f),
                 author = "TheLastShaymin"
             },
-
 
             new HatData
             {
@@ -282,7 +279,6 @@ namespace TownOfUs.CustomHats
             foreach (var hat in _hatDatas) yield return CreateHat(hat, ++i);
         }
 
-
         protected internal struct HatData
         {
             public bool bounce;
@@ -297,7 +293,7 @@ namespace TownOfUs.CustomHats
             public int framecount;
         }
 
-        [HarmonyPatch(typeof(HatManager), nameof(HatManager.GetHatById))]
+        //[HarmonyPatch(typeof(HatManager), nameof(HatManager.GetHatById))]
         public static class HatManagerPatch
         {
             private static bool Prefix(HatManager __instance)
@@ -313,8 +309,8 @@ namespace TownOfUs.CustomHats
                         {
                             var hat = CreateHat(hatData, id++);
                             __instance.AllHats.Add(hat);
-                            if (hatData.highUp) TallIds.Add((uint) (__instance.AllHats.Count - 1));
-                            IdToData.Add((uint) __instance.AllHats.Count - 1, hatData);
+                            if (hatData.highUp) TallIds.Add((uint)(__instance.AllHats.Count - 1));
+                            IdToData.Add((uint)__instance.AllHats.Count - 1, hatData);
                         }
                     }
 


### PR DESCRIPTION
This PR fixes the glitch where the mayor voting glitches out, frequently showing skips. This also has a few quick patches to cut down on the errors generated by hats being removed from the game temporarily, since I got annoyed by the blocks of red errors I kept seeing in the console.