### PR TITLE
fix(Underdog): change kill cooldown at the end of a meeting

### DIFF
--- a/source/Patches/ImpostorRoles/UnderdogMod/PatchKillTimer.cs
+++ b/source/Patches/ImpostorRoles/UnderdogMod/PatchKillTimer.cs
@@ -1,0 +1,20 @@
+﻿using HarmonyLib;
+using TownOfUs.Roles;
+using UnityEngine;
+
+namespace TownOfUs.ImpostorRoles.UnderdogMod
+{
+    [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.SetKillTimer))]
+    public static class PatchKillTimer
+    {
+        public static bool Prefix(PlayerControl __instance, [HarmonyArgument(0)] float time)
+        {
+            var role = Role.GetRole(__instance);
+            if (role?.RoleType != RoleEnum.Underdog) return true;
+            var maxTimer = ((Underdog)role).MaxTimer();
+            __instance.killTimer = Mathf.Clamp(time, 0, maxTimer);
+            HudManager.Instance.KillButton.SetCoolDown(__instance.killTimer, maxTimer);
+            return false;
+        }
+    }
+}

--- a/source/Patches/ImpostorRoles/UnderdogMod/PerformKill.cs
+++ b/source/Patches/ImpostorRoles/UnderdogMod/PerformKill.cs
@@ -1,5 +1,6 @@
-using System.Linq;
+﻿using System.Linq;
 using HarmonyLib;
+using TownOfUs.Roles;
 
 namespace TownOfUs.ImpostorRoles.UnderdogMod
 {
@@ -8,14 +9,15 @@ namespace TownOfUs.ImpostorRoles.UnderdogMod
     {
         public static void Postfix(PlayerControl __instance, [HarmonyArgument(0)] PlayerControl target)
         {
-            if (__instance.Is(RoleEnum.Underdog))
-                __instance.SetKillTimer(PlayerControl.GameOptions.KillCooldown * (LastImp() ? 0.5f : 1.5f));
+            var role = Role.GetRole(__instance);
+            if (role?.RoleType == RoleEnum.Underdog)
+                ((Underdog)role).SetKillTimer();
         }
 
         internal static bool LastImp()
         {
-            return PlayerControl.AllPlayerControls.ToArray().Count(x => x.Data.IsImpostor && !x.Data.IsDead) ==
-                   1;
+            return PlayerControl.AllPlayerControls.ToArray()
+                .Count(x => x.Data.IsImpostor && !x.Data.IsDead) == 1;
         }
     }
 }

--- a/source/Patches/ImpostorRoles/UnderdogMod/PostMeeting.cs
+++ b/source/Patches/ImpostorRoles/UnderdogMod/PostMeeting.cs
@@ -1,17 +1,18 @@
-using HarmonyLib;
+﻿using HarmonyLib;
 using UnityEngine;
 
 namespace TownOfUs.ImpostorRoles.UnderdogMod
 {
-    [HarmonyPatch(typeof(Object), nameof(Object.Destroy), typeof(Object))]
+    [HarmonyPatch(typeof(ExileController), nameof(ExileController.WrapUp))]
     public static class HUDClose
     {
-        public static void Postfix(Object obj)
+        public static void Postfix()
         {
-            if (ExileController.Instance == null || obj != ExileController.Instance.gameObject) return;
-            if (PlayerControl.LocalPlayer.Is(RoleEnum.Underdog))
-                PlayerControl.LocalPlayer.SetKillTimer(PlayerControl.GameOptions.KillCooldown *
-                                                       (PerformKill.LastImp() ? 0.5f : 1.5f));
+            var localPlayer = PlayerControl.LocalPlayer;
+            if (localPlayer.Is(RoleEnum.Underdog))
+                localPlayer.SetKillTimer(PlayerControl.GameOptions.KillCooldown * (
+                    PerformKill.LastImp() ? 0.5f : 1.5f
+                ));
         }
     }
 }

--- a/source/Patches/ImpostorRoles/UnderdogMod/PostMeeting.cs
+++ b/source/Patches/ImpostorRoles/UnderdogMod/PostMeeting.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using TownOfUs.Roles;
 using UnityEngine;
 
 namespace TownOfUs.ImpostorRoles.UnderdogMod
@@ -8,11 +9,9 @@ namespace TownOfUs.ImpostorRoles.UnderdogMod
     {
         public static void Postfix()
         {
-            var localPlayer = PlayerControl.LocalPlayer;
-            if (localPlayer.Is(RoleEnum.Underdog))
-                localPlayer.SetKillTimer(PlayerControl.GameOptions.KillCooldown * (
-                    PerformKill.LastImp() ? 0.5f : 1.5f
-                ));
+            var role = Role.GetRole(PlayerControl.LocalPlayer);
+            if (role?.RoleType == RoleEnum.Underdog)
+                ((Underdog)role).SetKillTimer();
         }
     }
 }

--- a/source/Patches/Roles/Underdog.cs
+++ b/source/Patches/Roles/Underdog.cs
@@ -1,3 +1,5 @@
+﻿using TownOfUs.ImpostorRoles.UnderdogMod;
+
 namespace TownOfUs.Roles
 {
     public class Underdog : Role
@@ -10,6 +12,15 @@ namespace TownOfUs.Roles
             Color = Palette.ImpostorRed;
             RoleType = RoleEnum.Underdog;
             Faction = Faction.Impostors;
+        }
+
+        public float MaxTimer() => PlayerControl.GameOptions.KillCooldown * (
+            PerformKill.LastImp() ? 0.5f : 1.5f
+        );
+
+        public void SetKillTimer()
+        {
+            Player.SetKillTimer(MaxTimer());
         }
     }
 }

--- a/source/TownOfUs.csproj
+++ b/source/TownOfUs.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>TownOfUs</RootNamespace>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -8,7 +8,7 @@
 
   <PropertyGroup>
     <GameProvider>Static</GameProvider>
-    <GameVersion>../../AmongUsModded2021615s/</GameVersion>
+    <GameVersion>../AmongUs</GameVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR fixes the underdog to multiply the kill cooldown at the end of a meeting