### PR TITLE
Tightens Underdog language in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,7 +680,7 @@ The Undertaker is an Impostor that can drag and drop bodies.
 ### **Team: Impostors**
 
 The Underdog is an Impostor with a prolonged kill cooldown.\
-Once their partener dies they will have their kill cooldown shortened.
+When they are the only remaining Impostor, they will have their kill cooldown shortened.
 
 ### Game Options
 | Name | Description | Type | Default |


### PR DESCRIPTION
The previous language implied that an impostor had to die to trigger the underdog. It said another impostor had to be killed to trigger the underdog. This isn't true; you merely have to be the last remaining impostor. This new language should help people understand better how the Underdog works in 1 or 3 impostor games.