### PR TITLE
feat(Assassin): only allow guessing enabled roles

### DIFF
--- a/source/Patches/CustomGameOptions.cs
+++ b/source/Patches/CustomGameOptions.cs
@@ -1,9 +1,10 @@
-using TownOfUs.CrewmateRoles.EngineerMod;
+﻿using TownOfUs.CrewmateRoles.EngineerMod;
 using TownOfUs.CrewmateRoles.MedicMod;
 using TownOfUs.CrewmateRoles.SeerMod;
 using TownOfUs.CustomOption;
 using TownOfUs.NeutralRoles.ExecutionerMod;
 using TownOfUs.NeutralRoles.ShifterMod;
+using System.Collections.Generic;
 
 namespace TownOfUs
 {
@@ -112,5 +113,35 @@ namespace TownOfUs
         public static bool AssassinCrewmateGuess => Generate.AssassinCrewmateGuess.Get();
         public static int AssassinKills => (int) Generate.AssassinKills.Get();
         public static bool AssassinMultiKill => Generate.AssassinMultiKill.Get();
+
+        public static List<RoleEnum> GetEnabledRoles(bool includeNeutrals = true)
+        {
+            bool On(int role) => role > 0;
+            var enabledRoles = new List<RoleEnum>();
+            if (On(SheriffOn)) enabledRoles.Add(RoleEnum.Sheriff);
+            if (On(EngineerOn)) enabledRoles.Add(RoleEnum.Engineer);
+            if (On(LoversOn)) enabledRoles.Add(RoleEnum.Lover);
+            if (On(MayorOn)) enabledRoles.Add(RoleEnum.Mayor);
+            if (On(SwapperOn)) enabledRoles.Add(RoleEnum.Swapper);
+            if (On(InvestigatorOn)) enabledRoles.Add(RoleEnum.Investigator);
+            if (On(TimeLordOn)) enabledRoles.Add(RoleEnum.TimeLord);
+            if (On(MedicOn)) enabledRoles.Add(RoleEnum.Medic);
+            if (On(SeerOn)) enabledRoles.Add(RoleEnum.Seer);
+            if (On(SpyOn)) enabledRoles.Add(RoleEnum.Spy);
+            if (On(SnitchOn)) enabledRoles.Add(RoleEnum.Snitch);
+            if (On(AltruistOn)) enabledRoles.Add(RoleEnum.Altruist);
+
+            if (includeNeutrals)
+            {
+                if (On(JesterOn)) enabledRoles.Add(RoleEnum.Jester);
+                if (On(ShifterOn)) enabledRoles.Add(RoleEnum.Shifter);
+                if (On(ExecutionerOn)) enabledRoles.Add(RoleEnum.Executioner);
+                if (On(ArsonistOn)) enabledRoles.Add(RoleEnum.Arsonist);
+                if (On(GlitchOn)) enabledRoles.Add(RoleEnum.Glitch);
+            }
+
+
+            return enabledRoles;
+        }
     }
 }

--- a/source/Patches/Handshake/ClientHandshake.cs
+++ b/source/Patches/Handshake/ClientHandshake.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using HarmonyLib;
@@ -58,7 +58,7 @@ namespace TownOfUs.Handshake
                         
                         // List<int> HandshakedClients - exists to disconnect legacy clients that don't send handshake
                         PluginSingleton<TownOfUs>.Instance.Log.LogMessage($"InnerNetClient.HandleMessage.Prefix - Adding {clientId} with TOU version {touVersion} to List<int>HandshakedClients");
-                        if (!HandshakedClients.Contains(clientId));
+                        if (!HandshakedClients.Contains(clientId))
                             HandshakedClients.Add(clientId);
 
                         if (touVersion != TOU_VERSION)

--- a/source/Patches/ImpostorRoles/AssassinMod/AddButton.cs
+++ b/source/Patches/ImpostorRoles/AssassinMod/AddButton.cs
@@ -75,7 +75,7 @@ namespace TownOfUs.ImpostorRoles.AssassinMod
             guess.transform.GetChild(0).gameObject.Destroy();
 
 
-            role.Guesses.Add(targetId, "None");
+            role.Guesses.Add(targetId, -1);
             role.Buttons[targetId] = (cycle, guess);
         }
 
@@ -84,14 +84,13 @@ namespace TownOfUs.ImpostorRoles.AssassinMod
             void Listener()
             {
                 if (MeetingHud.Instance.state == MeetingHud.VoteStates.Discussion) return;
-                var currentGuess = role.Guesses[voteArea.TargetPlayerId];
-                var guessIndex = currentGuess == "None"
-                    ? -1
-                    : role.PossibleGuesses.IndexOf(currentGuess);
-                if (++guessIndex == role.PossibleGuesses.Count)
-                    guessIndex = 0;
 
-                role.Guesses[voteArea.TargetPlayerId] = role.PossibleGuesses[guessIndex];
+                var currentGuessIdx = role.Guesses[voteArea.TargetPlayerId];
+                if (++currentGuessIdx == role.PossibleGuesses.Count)
+                    currentGuessIdx = 0;
+                PluginSingleton<TownOfUs>.Instance.Log.LogMessage($"Guess Index: {currentGuessIdx}");
+
+                role.Guesses[voteArea.TargetPlayerId] = currentGuessIdx;
             }
 
             return Listener;
@@ -106,12 +105,13 @@ namespace TownOfUs.ImpostorRoles.AssassinMod
                     IsExempt(voteArea)
                 ) return;
                 var targetId = voteArea.TargetPlayerId;
-                var currentGuess = role.Guesses[targetId];
-                if (currentGuess == "None") return;
+                var currentGuessIdx = role.Guesses[targetId];
+                if (currentGuessIdx == -1) return;
 
+                var currentGuess = role.PossibleGuesses[currentGuessIdx];
                 var playerRole = Role.GetRole(voteArea);
 
-                var toDie = playerRole.Name == currentGuess ? playerRole.Player : role.Player;
+                var toDie = playerRole.RoleType == currentGuess ? playerRole.Player : role.Player;
 
                 AssassinKill.RpcMurderPlayer(toDie);
                 role.RemainingKills--;

--- a/source/Patches/ImpostorRoles/AssassinMod/UpdateMeetingHud.cs
+++ b/source/Patches/ImpostorRoles/AssassinMod/UpdateMeetingHud.cs
@@ -16,12 +16,16 @@ namespace TownOfUs.ImpostorRoles.AssassinMod
             foreach (var voteArea in __instance.playerStates)
             {
                 var targetId = voteArea.TargetPlayerId;
-                assassin.Guesses.TryGetValue(targetId, out var currentGuess);
+                ;
 
                 if (
                     assassin.GuessedThisMeeting ||
-                    string.IsNullOrEmpty(currentGuess)
+                    !assassin.Guesses.TryGetValue(targetId, out var currentGuessIdx)
                 ) continue;
+
+                var currentGuess = currentGuessIdx == -1
+                    ? RoleEnum.None
+                    : assassin.PossibleGuesses[currentGuessIdx];
 
                 var playerData = Utils.PlayerById(targetId)?.Data;
                 if (playerData == null || playerData.Disconnected)
@@ -31,11 +35,11 @@ namespace TownOfUs.ImpostorRoles.AssassinMod
                     continue;
                 }
 
-                var nameText = "\n" + (currentGuess == "None"
+                var nameText = "\n" + (currentGuess == RoleEnum.None
                     ? "Guess"
                     : "<color=#" +
-                        assassin.ColorMapping[currentGuess].ToHtmlStringRGBA() +
-                    $">{currentGuess}??</color>"
+                        Role.GetColor(currentGuess).ToHtmlStringRGBA() +
+                    $">{Role.GetName(currentGuess)}??</color>"
                 );
 
                 voteArea.NameText.text += nameText;

--- a/source/Patches/Roles/Altruist.cs
+++ b/source/Patches/Roles/Altruist.cs
@@ -1,4 +1,4 @@
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace TownOfUs.Roles
 {
@@ -11,10 +11,8 @@ namespace TownOfUs.Roles
 
         public Altruist(PlayerControl player) : base(player)
         {
-            Name = "Altruist";
             ImpostorText = () => "Sacrifice yourself to save another";
             TaskText = () => "Revive a dead body at the cost of your own life.";
-            Color = new Color(0.4f, 0f, 0f, 1f);
             RoleType = RoleEnum.Altruist;
         }
     }

--- a/source/Patches/Roles/Arsonist.cs
+++ b/source/Patches/Roles/Arsonist.cs
@@ -18,10 +18,8 @@ namespace TownOfUs.Roles
 
         public Arsonist(PlayerControl player) : base(player)
         {
-            Name = "Arsonist";
             ImpostorText = () => "Douse players and ignite the light";
             TaskText = () => "Douse players and ignite to kill everyone\nFake Tasks:";
-            Color = new Color(1f, 0.3f, 0f);
             RoleType = RoleEnum.Arsonist;
             Faction = Faction.Neutral;
         }

--- a/source/Patches/Roles/Assassin.cs
+++ b/source/Patches/Roles/Assassin.cs
@@ -8,53 +8,30 @@ namespace TownOfUs.Roles
     {
         public Dictionary<byte, (GameObject, GameObject)> Buttons = new Dictionary<byte, (GameObject, GameObject)>();
 
+        public Dictionary<byte, int> Guesses = new Dictionary<byte, int>();
 
-        public Dictionary<string, Color> ColorMapping = new Dictionary<string, Color>
-        {
-            { "Mayor", new Color(0.44f, 0.31f, 0.66f, 1f) },
-            { "Sheriff", Color.yellow },
-            { "Engineer", new Color(1f, 0.65f, 0.04f, 1f) },
-            { "Swapper", new Color(0.4f, 0.9f, 0.4f, 1f) },
-            { "Investigator", new Color(0f, 0.7f, 0.7f, 1f) },
-            { "Time Lord", new Color(0f, 0f, 1f, 1f) },
-            { "Lover", new Color(1f, 0.4f, 0.8f, 1f) },
-            { "Medic", new Color(0f, 0.4f, 0f, 1f) },
-            { "Seer", new Color(1f, 0.8f, 0.5f, 1f) },
-            { "Spy", new Color(0.8f, 0.64f, 0.8f, 1f) },
-            { "Snitch", new Color(0.83f, 0.69f, 0.22f, 1f) },
-            { "Altruist", new Color(0.4f, 0f, 0f, 1f) }
-        };
-
-        public Dictionary<byte, string> Guesses = new Dictionary<byte, string>();
-
-
+        public List<RoleEnum> PossibleGuesses = new List<RoleEnum>();
         public Assassin(PlayerControl player) : base(player)
         {
-            Name = "Assassin";
             ImpostorText = () => "Kill during meetings if you can guess their roles";
             TaskText = () => "Guess the roles of the people and kill them mid-meeting";
-            Color = Palette.ImpostorRed;
             RoleType = RoleEnum.Assassin;
             Faction = Faction.Impostors;
 
             RemainingKills = CustomGameOptions.AssassinKills;
 
-            if (CustomGameOptions.AssassinGuessNeutrals)
-            {
-                ColorMapping.Add("Jester", new Color(1f, 0.75f, 0.8f, 1f));
-                ColorMapping.Add("Shifter", new Color(0.6f, 0.6f, 0.6f, 1f));
-                ColorMapping.Add("Executioner", new Color(0.55f, 0.25f, 0.02f, 1f));
-                ColorMapping.Add("The Glitch", Color.green);
-                ColorMapping.Add("Arsonist", new Color(1f, 0.3f, 0f));
-            }
+            PossibleGuesses = CustomGameOptions.GetEnabledRoles(
+                CustomGameOptions.AssassinGuessNeutrals
+            );
 
-            if (CustomGameOptions.AssassinCrewmateGuess) ColorMapping.Add("Crewmate", Color.white);
+            if (CustomGameOptions.AssassinCrewmateGuess)
+                PossibleGuesses.Add(RoleEnum.Crewmate);
+
+            PluginSingleton<TownOfUs>.Instance.Log.LogMessage($"Count: {PossibleGuesses.Count}");
         }
 
         public bool GuessedThisMeeting { get; set; } = false;
 
         public int RemainingKills { get; set; }
-
-        public List<string> PossibleGuesses => ColorMapping.Keys.ToList();
     }
 }

--- a/source/Patches/Roles/Camouflager.cs
+++ b/source/Patches/Roles/Camouflager.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using UnityEngine;
 
 namespace TownOfUs.Roles
@@ -13,10 +13,8 @@ namespace TownOfUs.Roles
 
         public Camouflager(PlayerControl player) : base(player)
         {
-            Name = "Camouflager";
             ImpostorText = () => "Camouflage and turn everyone grey";
             TaskText = () => "Camouflage and get secret kills";
-            Color = Palette.ImpostorRed;
             RoleType = RoleEnum.Camouflager;
             Faction = Faction.Impostors;
         }

--- a/source/Patches/Roles/Diener.cs
+++ b/source/Patches/Roles/Diener.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace TownOfUs.Roles
 {
@@ -8,10 +8,8 @@ namespace TownOfUs.Roles
 
         public Undertaker(PlayerControl player) : base(player)
         {
-            Name = "Undertaker";
             ImpostorText = () => "Drag bodies and hide them";
             TaskText = () => "Drag bodies around to hide them from being reported";
-            Color = Palette.ImpostorRed;
             RoleType = RoleEnum.Undertaker;
             Faction = Faction.Impostors;
         }

--- a/source/Patches/Roles/Engineer.cs
+++ b/source/Patches/Roles/Engineer.cs
@@ -1,4 +1,4 @@
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace TownOfUs.Roles
 {
@@ -6,10 +6,8 @@ namespace TownOfUs.Roles
     {
         public Engineer(PlayerControl player) : base(player)
         {
-            Name = "Engineer";
             ImpostorText = () => "Maintain important systems on the ship";
             TaskText = () => "Vent and fix a sabotage from anywhere!";
-            Color = new Color(1f, 0.65f, 0.04f, 1f);
             RoleType = RoleEnum.Engineer;
         }
 

--- a/source/Patches/Roles/Executioner.cs
+++ b/source/Patches/Roles/Executioner.cs
@@ -1,4 +1,4 @@
-using Il2CppSystem.Collections.Generic;
+﻿using Il2CppSystem.Collections.Generic;
 using UnityEngine;
 
 namespace TownOfUs.Roles
@@ -10,14 +10,12 @@ namespace TownOfUs.Roles
 
         public Executioner(PlayerControl player) : base(player)
         {
-            Name = "Executioner";
             ImpostorText = () =>
                 target == null ? "You don't have a target for some reason... weird..." : $"Vote {target.name} out";
             TaskText = () =>
                 target == null
                     ? "You don't have a target for some reason... weird..."
                     : $"Vote {target.name} out\nFake Tasks:";
-            Color = new Color(0.55f, 0.25f, 0.02f, 1f);
             RoleType = RoleEnum.Executioner;
             Faction = Faction.Neutral;
             Scale = 1.4f;

--- a/source/Patches/Roles/Glitch.cs
+++ b/source/Patches/Roles/Glitch.cs
@@ -24,8 +24,6 @@ namespace TownOfUs.Roles
 
         public Glitch(PlayerControl owner) : base(owner)
         {
-            Name = "The Glitch";
-            Color = Color.green;
             LastHack = DateTime.UtcNow;
             LastMimic = DateTime.UtcNow;
             LastKill = DateTime.UtcNow;

--- a/source/Patches/Roles/Investigator.cs
+++ b/source/Patches/Roles/Investigator.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using TownOfUs.CrewmateRoles.InvestigatorMod;
 using UnityEngine;
 
@@ -11,10 +11,8 @@ namespace TownOfUs.Roles
 
         public Investigator(PlayerControl player) : base(player)
         {
-            Name = "Investigator";
             ImpostorText = () => "Find all imposters by examining footprints";
             TaskText = () => "You can see everyone's footprints.";
-            Color = new Color(0f, 0.7f, 0.7f, 1f);
             RoleType = RoleEnum.Investigator;
             Scale = 1.4f;
         }

--- a/source/Patches/Roles/Janitor.cs
+++ b/source/Patches/Roles/Janitor.cs
@@ -1,4 +1,4 @@
-namespace TownOfUs.Roles
+﻿namespace TownOfUs.Roles
 {
     public class Janitor : Role
     {
@@ -6,10 +6,8 @@ namespace TownOfUs.Roles
 
         public Janitor(PlayerControl player) : base(player)
         {
-            Name = "Janitor";
             ImpostorText = () => "Clean up bodies";
             TaskText = () => "Clean bodies to prevent Crewmates from discovering them.";
-            Color = Palette.ImpostorRed;
             RoleType = RoleEnum.Janitor;
             Faction = Faction.Impostors;
         }

--- a/source/Patches/Roles/Jester.cs
+++ b/source/Patches/Roles/Jester.cs
@@ -1,4 +1,4 @@
-using Il2CppSystem.Collections.Generic;
+﻿using Il2CppSystem.Collections.Generic;
 using UnityEngine;
 
 namespace TownOfUs.Roles
@@ -10,10 +10,8 @@ namespace TownOfUs.Roles
 
         public Jester(PlayerControl player) : base(player)
         {
-            Name = "Jester";
             ImpostorText = () => "Get voted out";
             TaskText = () => "Get voted out!\nFake Tasks:";
-            Color = new Color(1f, 0.75f, 0.8f, 1f);
             RoleType = RoleEnum.Jester;
             Faction = Faction.Neutral;
         }

--- a/source/Patches/Roles/Lover.cs
+++ b/source/Patches/Roles/Lover.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Hazel;
 using TownOfUs.CustomHats;
@@ -12,8 +12,6 @@ namespace TownOfUs.Roles
         public Lover(PlayerControl player, int num, bool loverImpostor) : base(player)
         {
             var imp = num == 2 && loverImpostor;
-            Name = imp ? "Loving Impostor" : "Lover";
-            Color = new Color(1f, 0.4f, 0.8f, 1f);
             ImpostorText = () =>
                 "You are in " + ColorString + "Love</color> with " + ColorString + OtherLover.Player.name;
             TaskText = () => $"Stay alive with your love {OtherLover.Player.name} \n and win together";

--- a/source/Patches/Roles/Mayor.cs
+++ b/source/Patches/Roles/Mayor.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using UnityEngine;
 
 namespace TownOfUs.Roles
@@ -9,10 +9,8 @@ namespace TownOfUs.Roles
 
         public Mayor(PlayerControl player) : base(player)
         {
-            Name = "Mayor";
             ImpostorText = () => "Save your votes to double vote";
             TaskText = () => "Save your votes to vote multiple times";
-            Color = new Color(0.44f, 0.31f, 0.66f, 1f);
             RoleType = RoleEnum.Mayor;
             VoteBank = CustomGameOptions.MayorVoteBank;
         }

--- a/source/Patches/Roles/Medic.cs
+++ b/source/Patches/Roles/Medic.cs
@@ -1,4 +1,4 @@
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace TownOfUs.Roles
 {
@@ -6,10 +6,8 @@ namespace TownOfUs.Roles
     {
         public Medic(PlayerControl player) : base(player)
         {
-            Name = "Medic";
             ImpostorText = () => "Create a shield to protect a crewmate";
             TaskText = () => "Protect a crewmate with a shield";
-            Color = new Color(0f, 0.4f, 0f, 1f);
             RoleType = RoleEnum.Medic;
             ShieldedPlayer = null;
         }

--- a/source/Patches/Roles/Miner.cs
+++ b/source/Patches/Roles/Miner.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -14,10 +14,8 @@ namespace TownOfUs.Roles
 
         public Miner(PlayerControl player) : base(player)
         {
-            Name = "Miner";
             ImpostorText = () => "From the top, make it drop, that's a vent";
             TaskText = () => "From the top, make it drop, that's a vent";
-            Color = Palette.ImpostorRed;
             RoleType = RoleEnum.Miner;
             Faction = Faction.Impostors;
         }

--- a/source/Patches/Roles/Morphling.cs
+++ b/source/Patches/Roles/Morphling.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using TownOfUs.Extensions;
 using TownOfUs.Roles.Modifiers;
 using UnityEngine;
@@ -18,10 +18,8 @@ namespace TownOfUs.Roles
 
         public Morphling(PlayerControl player) : base(player)
         {
-            Name = "Morphling";
             ImpostorText = () => "Transform into crewmates";
             TaskText = () => "Morph into crewmates to be disguised";
-            Color = Palette.ImpostorRed;
             RoleType = RoleEnum.Morphling;
             Faction = Faction.Impostors;
         }

--- a/source/Patches/Roles/Phantom.cs
+++ b/source/Patches/Roles/Phantom.cs
@@ -1,4 +1,4 @@
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace TownOfUs.Roles
 {
@@ -10,10 +10,8 @@ namespace TownOfUs.Roles
 
         public Phantom(PlayerControl player) : base(player)
         {
-            Name = "Phantom";
             ImpostorText = () => "";
             TaskText = () => "Complete all your tasks without being caught!";
-            Color = new Color(0.4f, 0.16f, 0.38f, 1f);
             RoleType = RoleEnum.Phantom;
             Faction = Faction.Neutral;
         }

--- a/source/Patches/Roles/Role.cs
+++ b/source/Patches/Roles/Role.cs
@@ -1,4 +1,4 @@
-using HarmonyLib;
+﻿using HarmonyLib;
 using Hazel;
 using System;
 using System.Collections.Generic;
@@ -33,7 +33,6 @@ namespace TownOfUs.Roles
         }
 
         public static IEnumerable<Role> AllRoles => RoleDictionary.Values.ToList();
-        protected internal string Name { get; set; }
 
         private PlayerControl _player { get; set; }
 
@@ -49,8 +48,9 @@ namespace TownOfUs.Roles
             }
         }
 
+        public string Name => GetName(RoleType, false);
+        public Color Color => GetColor(RoleType);
         protected float Scale { get; set; } = 1f;
-        protected internal Color Color { get; set; }
         protected internal RoleEnum RoleType { get; set; }
 
         protected internal bool Hidden { get; set; } = false;
@@ -259,6 +259,79 @@ namespace TownOfUs.Roles
         public static IEnumerable<Role> GetRoles(RoleEnum roletype)
         {
             return AllRoles.Where(x => x.RoleType == roletype);
+        }
+
+        public static Color GetColor(RoleEnum roleType) => roleType switch
+        {
+            RoleEnum.Sheriff => Color.yellow,
+            RoleEnum.Jester => new Color(1f, 0.75f, 0.8f, 1f),
+            RoleEnum.Engineer => new Color(1f, 0.65f, 0.04f, 1f),
+            RoleEnum.LoverImpostor => new Color(1f, 0.4f, 0.8f, 1f),
+            RoleEnum.Lover => new Color(1f, 0.4f, 0.8f, 1f),
+            RoleEnum.Mayor => new Color(0.44f, 0.31f, 0.66f, 1f),
+            RoleEnum.Swapper => new Color(0.4f, 0.9f, 0.4f, 1f),
+            RoleEnum.Investigator => new Color(0f, 0.7f, 0.7f, 1f),
+            RoleEnum.TimeLord => new Color(0f, 0f, 1f, 1f),
+            RoleEnum.Shifter => new Color(0.6f, 0.6f, 0.6f, 1f),
+            RoleEnum.Medic => new Color(0f, 0.4f, 0f, 1f),
+            RoleEnum.Seer => new Color(1f, 0.8f, 0.5f, 1f),
+            RoleEnum.Executioner => new Color(0.55f, 0.25f, 0.02f, 1f),
+            RoleEnum.Spy => new Color(0.8f, 0.64f, 0.8f, 1f),
+            RoleEnum.Snitch => new Color(0.83f, 0.69f, 0.22f, 1f),
+            RoleEnum.Arsonist => new Color(1f, 0.3f, 0f),
+            RoleEnum.Altruist => new Color(0.4f, 0f, 0f, 1f),
+            RoleEnum.Phantom => new Color(0.4f, 0.16f, 0.38f, 1f),
+            RoleEnum.Miner => Palette.ImpostorRed,
+            RoleEnum.Swooper => Palette.ImpostorRed,
+            RoleEnum.Morphling => Palette.ImpostorRed,
+            RoleEnum.Camouflager => Palette.ImpostorRed,
+            RoleEnum.Janitor => Palette.ImpostorRed,
+            RoleEnum.Undertaker => Palette.ImpostorRed,
+            RoleEnum.Assassin => Palette.ImpostorRed,
+            RoleEnum.Underdog => Palette.ImpostorRed,
+            RoleEnum.Glitch => Color.green,
+            RoleEnum.Impostor => Palette.ImpostorRed,
+            _ => Color.white
+        };
+
+        public static string GetName(RoleEnum roleId, bool includeColor = false)
+        {
+            var roleName = roleId switch
+            {
+                RoleEnum.Sheriff => "Sheriff",
+                RoleEnum.Jester => "Jester",
+                RoleEnum.Engineer => "Engineer",
+                RoleEnum.LoverImpostor => "Loving Impostor",
+                RoleEnum.Lover => "Lover",
+                RoleEnum.Mayor => "Mayor",
+                RoleEnum.Swapper => "Swapper",
+                RoleEnum.Investigator => "Investigator",
+                RoleEnum.TimeLord => "Time Lord",
+                RoleEnum.Shifter => "Shifter",
+                RoleEnum.Medic => "Medic",
+                RoleEnum.Seer => "Seer",
+                RoleEnum.Executioner => "Executioner",
+                RoleEnum.Spy => "Spy",
+                RoleEnum.Snitch => "Snitch",
+                RoleEnum.Arsonist => "Arsonist",
+                RoleEnum.Altruist => "Altruist",
+                RoleEnum.Phantom => "Phantom",
+                RoleEnum.Miner => "Miner",
+                RoleEnum.Swooper => "Swooper",
+                RoleEnum.Morphling => "Morphling",
+                RoleEnum.Camouflager => "Camouflager",
+                RoleEnum.Janitor => "Janitor",
+                RoleEnum.Undertaker => "Undertaker",
+                RoleEnum.Assassin => "Assassin",
+                RoleEnum.Underdog => "Underdog",
+                RoleEnum.Glitch => "The Glitch",
+                RoleEnum.Impostor => "Impostor",
+                _ => "Crewmate",
+            };
+
+            return includeColor
+                ? $"<color=#{GetColor(roleId).ToHtmlStringRGBA()}>{roleName}</color>"
+                : roleName;
         }
 
         public static class IntroCutScenePatch

--- a/source/Patches/Roles/Seer.cs
+++ b/source/Patches/Roles/Seer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using TownOfUs.CrewmateRoles.SeerMod;
 using UnityEngine;
@@ -11,10 +11,8 @@ namespace TownOfUs.Roles
 
         public Seer(PlayerControl player) : base(player)
         {
-            Name = "Seer";
             ImpostorText = () => "Investigate roles";
             TaskText = () => "Investigate roles and find the Impostor";
-            Color = new Color(1f, 0.8f, 0.5f, 1f);
             RoleType = RoleEnum.Seer;
         }
 

--- a/source/Patches/Roles/Sheriff.cs
+++ b/source/Patches/Roles/Sheriff.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using UnityEngine;
 
 namespace TownOfUs.Roles
@@ -7,10 +7,8 @@ namespace TownOfUs.Roles
     {
         public Sheriff(PlayerControl player) : base(player)
         {
-            Name = "Sheriff";
             ImpostorText = () => "Shoot the <color=#FF0000FF>Impostor</color>";
             TaskText = () => "Kill off the impostor but don't kill crewmates.";
-            Color = Color.yellow;
             RoleType = RoleEnum.Sheriff;
         }
 

--- a/source/Patches/Roles/Shifter.cs
+++ b/source/Patches/Roles/Shifter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using UnityEngine;
 
 namespace TownOfUs.Roles
@@ -7,10 +7,8 @@ namespace TownOfUs.Roles
     {
         public Shifter(PlayerControl player) : base(player)
         {
-            Name = "Shifter";
             ImpostorText = () => "Shift around different roles";
             TaskText = () => "Steal other people's roles.\nFake Tasks:";
-            Color = new Color(0.6f, 0.6f, 0.6f, 1f);
             RoleType = RoleEnum.Shifter;
             Faction = Faction.Neutral;
         }

--- a/source/Patches/Roles/Snitch.cs
+++ b/source/Patches/Roles/Snitch.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using TownOfUs.CustomHats;
 using TownOfUs.ImpostorRoles.CamouflageMod;
 using UnityEngine;
@@ -17,13 +17,11 @@ namespace TownOfUs.Roles
 
         public Snitch(PlayerControl player) : base(player)
         {
-            Name = "Snitch";
             ImpostorText = () => "Complete all your tasks to discover the Impostors";
             TaskText = () =>
                 TasksDone
                     ? "Find the arrows pointing to the Impostors!"
                     : "Complete all your tasks to discover the Impostors!";
-            Color = new Color(0.83f, 0.69f, 0.22f, 1f);
             Hidden = !CustomGameOptions.SnitchOnLaunch;
             RoleType = RoleEnum.Snitch;
         }

--- a/source/Patches/Roles/Spy.cs
+++ b/source/Patches/Roles/Spy.cs
@@ -1,4 +1,4 @@
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace TownOfUs.Roles
 {
@@ -6,10 +6,8 @@ namespace TownOfUs.Roles
     {
         public Spy(PlayerControl player) : base(player)
         {
-            Name = "Spy";
             ImpostorText = () => "Snoop around and find stuff out";
             TaskText = () => "Spy on people and find the Impostors";
-            Color = new Color(0.8f, 0.64f, 0.8f, 1f);
             RoleType = RoleEnum.Spy;
         }
     }

--- a/source/Patches/Roles/Swapper.cs
+++ b/source/Patches/Roles/Swapper.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using UnityEngine;
 
 namespace TownOfUs.Roles
@@ -12,10 +12,8 @@ namespace TownOfUs.Roles
 
         public Swapper(PlayerControl player) : base(player)
         {
-            Name = "Swapper";
             ImpostorText = () => "Swap the votes of two people";
             TaskText = () => "Swap two people's votes and wreak havoc!";
-            Color = new Color(0.4f, 0.9f, 0.4f, 1f);
             RoleType = RoleEnum.Swapper;
         }
     }

--- a/source/Patches/Roles/Swooper.cs
+++ b/source/Patches/Roles/Swooper.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using UnityEngine;
 using Object = UnityEngine.Object;
 
@@ -13,10 +13,8 @@ namespace TownOfUs.Roles
 
         public Swooper(PlayerControl player) : base(player)
         {
-            Name = "Swooper";
             ImpostorText = () => "Turn invisible temporarily";
             TaskText = () => "Turn invisible and sneakily kill";
-            Color = Palette.ImpostorRed;
             RoleType = RoleEnum.Swooper;
             Faction = Faction.Impostors;
         }

--- a/source/Patches/Roles/TimeLord.cs
+++ b/source/Patches/Roles/TimeLord.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using TownOfUs.CrewmateRoles.TimeLordMod;
 using UnityEngine;
 
@@ -8,10 +8,8 @@ namespace TownOfUs.Roles
     {
         public TimeLord(PlayerControl player) : base(player)
         {
-            Name = "Time Lord";
             ImpostorText = () => "Rewind Time";
             TaskText = () => "Rewind Time!";
-            Color = new Color(0f, 0f, 1f, 1f);
             RoleType = RoleEnum.TimeLord;
             Scale = 1.4f;
         }

--- a/source/Patches/Roles/Underdog.cs
+++ b/source/Patches/Roles/Underdog.cs
@@ -6,10 +6,8 @@ namespace TownOfUs.Roles
     {
         public Underdog(PlayerControl player) : base(player)
         {
-            Name = "Underdog";
             ImpostorText = () => "Use your comeback power to win";
             TaskText = () => "long kill cooldown when 2 imps, short when 1 imp";
-            Color = Palette.ImpostorRed;
             RoleType = RoleEnum.Underdog;
             Faction = Faction.Impostors;
         }

--- a/source/Patches/Roles/Vanilla.cs
+++ b/source/Patches/Roles/Vanilla.cs
@@ -1,4 +1,4 @@
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace TownOfUs.Roles
 {
@@ -6,11 +6,9 @@ namespace TownOfUs.Roles
     {
         public Impostor(PlayerControl player) : base(player)
         {
-            Name = "Impostor";
             Hidden = true;
             Faction = Faction.Impostors;
             RoleType = RoleEnum.Impostor;
-            Color = Palette.ImpostorRed;
         }
     }
 
@@ -18,11 +16,9 @@ namespace TownOfUs.Roles
     {
         public Crewmate(PlayerControl player) : base(player)
         {
-            Name = "Crewmate";
             Hidden = true;
             Faction = Faction.Crewmates;
             RoleType = RoleEnum.Crewmate;
-            Color = Color.white;
         }
     }
 }


### PR DESCRIPTION
This PR changes the assassin to only be able to guess roles that are enabled

note: by enabled this means the role is on a 1% chance or higher, not if someone actually has it

simply saves time cycling through roles that aren't even on