### PR TITLE
fix: check if killer is the local player

### DIFF
--- a/source/Patches/Utils.cs
+++ b/source/Patches/Utils.cs
@@ -382,6 +382,8 @@ namespace TownOfUs
 
                 Murder.KilledPlayers.Add(deadBody);
 
+                if (!killer.AmOwner) return;
+
                 if (target.Is(ModifierEnum.Diseased) && killer.Is(RoleEnum.Glitch))
                 {
                     var glitch = Role.GetRole<Glitch>(killer);


### PR DESCRIPTION
This PR fixes the kill button flashing when someone gets a kill