### PR TITLE
fix: better role generation

### DIFF
--- a/source/Patches/Roles/Modifiers/Modifier.cs
+++ b/source/Patches/Roles/Modifiers/Modifier.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Hazel;
@@ -56,25 +56,6 @@ namespace TownOfUs.Roles.Modifiers
         public static bool operator !=(Modifier a, Modifier b)
         {
             return !(a == b);
-        }
-
-        public static void Gen(Type T, List<PlayerControl> crewmates, CustomRPC rpc)
-        {
-            //System.Console.WriteLine(nameof(rpc));
-            //System.Console.WriteLine(crewmates.Count);
-            if (crewmates.Count <= 0) return;
-            var rand = Random.RandomRangeInt(0, crewmates.Count);
-            //var rand = 0;
-            var pc = crewmates[rand];
-
-            var role = Activator.CreateInstance(T, new object[] {pc});
-            var playerId = pc.PlayerId;
-            crewmates.Remove(pc);
-
-            var writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte) rpc,
-                SendOption.Reliable, -1);
-            writer.Write(playerId);
-            AmongUsClient.Instance.FinishRpcImmediately(writer);
         }
 
         public static Modifier GetModifier(PlayerControl player)

--- a/source/Patches/Roles/Role.cs
+++ b/source/Patches/Roles/Role.cs
@@ -226,7 +226,6 @@ namespace TownOfUs.Roles
                 (byte)rpc, SendOption.Reliable, -1);
             writer.Write(player.PlayerId);
             AmongUsClient.Instance.FinishRpcImmediately(writer);
-            TownOfUs.LogMessage($"Genering {rpc} for {player.name}");
             return role;
         }
 

--- a/source/Patches/RpcHandling.cs
+++ b/source/Patches/RpcHandling.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using HarmonyLib;
@@ -26,8 +26,6 @@ namespace TownOfUs
 {
     public static class RpcHandling
     {
-        //public static readonly System.Random Rand = new System.Random();
-
         private static readonly List<(Type, CustomRPC, int)> CrewmateRoles = new List<(Type, CustomRPC, int)>();
         private static readonly List<(Type, CustomRPC, int)> NeutralRoles = new List<(Type, CustomRPC, int)>();
         private static readonly List<(Type, CustomRPC, int)> ImpostorRoles = new List<(Type, CustomRPC, int)>();
@@ -38,14 +36,13 @@ namespace TownOfUs
 
         internal static bool Check(int probability)
         {
-            //System.Console.WriteLine("Check");
-            if (probability >= 100) return true;
-            if (probability <= 0) return false;
-            var num = Random.RandomRangeInt(0, 101) + 1;
+            if (probability == 0) return false;
+            if (probability == 100) return true;
+            var num = Random.RandomRangeInt(1, 101);
             return num <= probability;
         }
 
-
+        /*
         private static void GenExe(List<GameData.PlayerInfo> infected, List<PlayerControl> crewmates)
         {
             PlayerControl pc;
@@ -72,34 +69,49 @@ namespace TownOfUs
                     ((Executioner) role).target = pc;
                 }
             }
+        }*/
+
+        private static void SortRoles(List<(Type, CustomRPC, int)> roles, int max = int.MaxValue)
+        {
+            roles.Shuffle();
+            roles.Sort((a, b) =>
+            {
+                var a_ = a.Item3 == 100 ? 0 : 100;
+                var b_ = b.Item3 == 100 ? 0 : 100;
+                return a_.CompareTo(b_);
+            });
+            if (roles.Count > max)
+                while (roles.Count > max)
+                    roles.RemoveAt(roles.Count - 1);
         }
 
         private static void GenEachRole(List<GameData.PlayerInfo> infected)
         {
-            //System.Console.WriteLine("REACHED HERE - GEN ROLES");
-            CrewmateRoles.Shuffle();
-            NeutralRoles.Shuffle();
-            var neutralRoles = NeutralRoles.Take(CustomGameOptions.MaxNeutralRoles).ToList();
-            var crewAndNeutRoles = neutralRoles;
-            crewAndNeutRoles.AddRange(CrewmateRoles);
-            crewAndNeutRoles.Shuffle();
-            crewAndNeutRoles.Sort((a, b) =>
-            {
-                var a_ = a.Item3 == 100 ? 0 : 100;
-                var b_ = b.Item3 == 100 ? 0 : 100;
-                return a_.CompareTo(b_);
-            });
+            var impostors = Utils.GetImpostors(infected);
+            var crewmates = Utils.GetCrewmates(impostors);
+            crewmates.Shuffle();
+            impostors.Shuffle();
 
-            CrewmateModifiers.Shuffle();
-            GlobalModifiers.Shuffle();
+            SortRoles(CrewmateRoles);
+            SortRoles(NeutralRoles, CustomGameOptions.MaxNeutralRoles);
+            SortRoles(ImpostorRoles, Math.Min(impostors.Count, CustomGameOptions.MaxImpostorRoles));
+            SortRoles(CrewmateModifiers, crewmates.Count);
+            SortRoles(GlobalModifiers, crewmates.Count + impostors.Count);
 
-            ImpostorRoles.Shuffle();
-            ImpostorRoles.Sort((a, b) =>
+            var crewAndNeutralRoles = new List<(Type, CustomRPC, int)>();
+            crewAndNeutralRoles.AddRange(NeutralRoles);
+            crewAndNeutralRoles.AddRange(CrewmateRoles);
+            SortRoles(crewAndNeutralRoles, crewmates.Count);
+
+            foreach (var (_, rpc, _) in crewAndNeutralRoles)
             {
-                var a_ = a.Item3 == 100 ? 0 : 100;
-                var b_ = b.Item3 == 100 ? 0 : 100;
-                return a_.CompareTo(b_);
-            });
+                TownOfUs.LogMessage($"Enabled Crew/Neut Role: {rpc}");
+            }
+
+            foreach (var (_, rpc, _) in ImpostorRoles)
+            {
+                TownOfUs.LogMessage($"Enabled Imp Role: {rpc}");
+            }
 
             if (Check(CustomGameOptions.VanillaGame))
             {
@@ -107,74 +119,78 @@ namespace TownOfUs
                 NeutralRoles.Clear();
                 CrewmateModifiers.Clear();
                 GlobalModifiers.Clear();
-                LoversOn = false;
                 ImpostorRoles.Clear();
-                crewAndNeutRoles.Clear();
+                LoversOn = false;
                 PhantomOn = false;
             }
 
-            var crewmates = Utils.getCrewmates(infected);
-            var impostors = Utils.getImpostors(infected);
-            var impRoles = ImpostorRoles.Take(CustomGameOptions.MaxImpostorRoles);
+            PlayerControl executioner = null;
 
-
-            var executionerOn = false;
-
-
-            foreach (var y in crewAndNeutRoles.Select(x => x.Item2.ToString())) System.Console.WriteLine(y + "- c&n");
-            foreach (var y in CrewmateRoles.Select(x => x.Item2.ToString())) System.Console.WriteLine(y + "- c");
-            foreach (var y in infected.Select(x => x.PlayerId.ToString())) System.Console.WriteLine(y);
-
-            /*System.Console.WriteLine(from x in crewAndNeutRoles select x.Item2.ToString());
-            System.Console.WriteLine(from x in infected select x.PlayerId);*/
-
-            foreach (var (role, rpc, _perc) in crewAndNeutRoles)
+            foreach (var (type, rpc, _) in crewAndNeutralRoles)
             {
                 if (rpc == CustomRPC.SetExecutioner)
                 {
-                    executionerOn = true;
+                    executioner = crewmates[Random.RandomRangeInt(0, crewmates.Count)];
+                    crewmates.Remove(executioner);
                     continue;
                 }
-
-                //System.Console.WriteLine(role);
-                //System.Console.WriteLine(rpc);
-                Role.Gen(role, crewmates, rpc);
+                    
+                Role.Gen<Role>(type, crewmates, rpc);
             }
-
-            if (executionerOn) GenExe(infected, crewmates);
-
-
-            foreach (var (role, rpc, _perc) in impRoles)
-                //System.Console.WriteLine(role);
-                //System.Console.WriteLine(rpc);
-                Role.Gen(role, impostors, rpc);
-
-            var crewmates2 = Utils.getCrewmates(infected).Where(x => !x.Is(RoleEnum.Glitch)).ToList();
-            foreach (var (modifier, rpc, _perc) in CrewmateModifiers)
-                //System.Console.WriteLine(modifier);
-                //System.Console.WriteLine(rpc);
-                Modifier.Gen(modifier, crewmates2, rpc);
-
-            var global = PlayerControl.AllPlayerControls.ToArray()
-                .Where(x => Modifier.GetModifier(x) == null && !x.Is(RoleEnum.Glitch)).ToList();
-            foreach (var (modifier, rpc, _perc) in GlobalModifiers) Modifier.Gen(modifier, global, rpc);
 
             if (LoversOn)
-                //System.Console.WriteLine("LOVER1");
                 Lover.Gen(crewmates, impostors);
 
-            while (true)
+            foreach (var (type, rpc, _) in ImpostorRoles)
+                Role.Gen<Role>(type, impostors, rpc);
+
+            foreach (var crewmate in crewmates)
+                Role.Gen<Role>(typeof(Crewmate), crewmate, CustomRPC.SetCrewmate);
+
+            foreach (var impostor in impostors)
+                Role.Gen<Role>(typeof(Impostor), impostor, CustomRPC.SetImpostor);
+
+            if (executioner != null)
             {
-                if (crewmates.Count == 0) break;
-                Role.Gen(typeof(Crewmate), crewmates, CustomRPC.SetCrewmate);
+                var targets = Utils.GetCrewmates(impostors).Where(
+                    crewmate => Role.GetRole(crewmate)?.Faction == Faction.Crewmates
+                ).ToList();
+                TownOfUs.LogMessage($"Executioner Targets ({targets.Count})");
+                foreach (var target in targets)
+                    TownOfUs.LogMessage(target.name);
+                if (targets.Count > 0)
+                {
+                    var exec = Role.Gen<Executioner>(
+                        typeof(Executioner),
+                        executioner,
+                        CustomRPC.SetExecutioner
+                    );
+                    var target = exec.target = targets[Random.RandomRangeInt(0, targets.Count)];
+
+                    var writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId,
+                        (byte)CustomRPC.SetTarget, SendOption.Reliable, -1);
+                    writer.Write(executioner.PlayerId);
+                    writer.Write(target.PlayerId);
+                    AmongUsClient.Instance.FinishRpcImmediately(writer);
+                }
+                else
+                    Role.Gen<Role>(typeof(Crewmate), executioner, CustomRPC.SetExecutioner);
             }
 
-            while (true)
-            {
-                if (impostors.Count == 0) break;
-                Role.Gen(typeof(Impostor), impostors, CustomRPC.SetImpostor);
-            }
+            var canHaveModifier = PlayerControl.AllPlayerControls.ToArray().ToList();
+            canHaveModifier.Shuffle();
 
+            foreach (var (type, rpc, _) in GlobalModifiers)
+                Role.Gen<Modifier>(type, canHaveModifier, rpc);
+
+            canHaveModifier.RemoveAll(player => !player.Data.IsImpostor);
+            canHaveModifier.Shuffle();
+
+            foreach (var player in canHaveModifier)
+            {
+                var (type, rpc, _) = CrewmateModifiers.TakeFirst();
+                Role.Gen<Modifier>(type, player, rpc);
+            }
 
             if (PhantomOn)
             {
@@ -189,16 +205,14 @@ namespace TownOfUs
                 SetPhantom.WillBePhantom = pc;
 
                 var writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId,
-                    (byte) CustomRPC.SetPhantom, SendOption.Reliable, -1);
+                    (byte)CustomRPC.SetPhantom, SendOption.Reliable, -1);
                 writer.Write(pc.PlayerId);
                 AmongUsClient.Instance.FinishRpcImmediately(writer);
-
-                System.Console.WriteLine(pc.Data.PlayerName);
             }
             else
             {
                 var writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId,
-                    (byte) CustomRPC.SetPhantom, SendOption.Reliable, -1);
+                    (byte)CustomRPC.SetPhantom, SendOption.Reliable, -1);
                 writer.Write(byte.MaxValue);
                 AmongUsClient.Instance.FinishRpcImmediately(writer);
             }
@@ -691,7 +705,6 @@ namespace TownOfUs
         {
             public static void Prefix([HarmonyArgument(0)] ref Il2CppReferenceArray<GameData.PlayerInfo> infected)
             {
-                //System.Console.WriteLine("REACHED HERE");
                 Utils.ShowDeadBodies = false;
                 Role.NobodyWins = false;
                 CrewmateRoles.Clear();
@@ -700,20 +713,6 @@ namespace TownOfUs
                 CrewmateModifiers.Clear();
                 GlobalModifiers.Clear();
 
-                /*var crewmates = Utils.getCrewmates(infected);
-                if (Check(20))
-                {
-                    var bloody = crewmates.FirstOrDefault(x => x.Data.PlayerName == "Bloody");
-                    if (bloody != null && infected.Count > 0)
-                    {
-                        infected[0] = bloody.Data;
-                    }
-                }*/
-
-
-                //TODO - Instantiate role-specific stuff
-                /*EngineerMod.PerformKill.UsedThisRound = false;
-                EngineerMod.PerformKill.SabotageTime = DateTime.UtcNow.AddSeconds(-100);*/
                 RecordRewind.points.Clear();
                 Murder.KilledPlayers.Clear();
                 KillButtonTarget.DontRevive = byte.MaxValue;
@@ -726,12 +725,9 @@ namespace TownOfUs
                 LoversOn = Check(CustomGameOptions.LoversOn);
                 PhantomOn = Check(CustomGameOptions.PhantomOn);
 
-
+                #region Crewmate Roles
                 if (Check(CustomGameOptions.MayorOn))
                     CrewmateRoles.Add((typeof(Mayor), CustomRPC.SetMayor, CustomGameOptions.MayorOn));
-
-                if (Check(CustomGameOptions.JesterOn))
-                    NeutralRoles.Add((typeof(Jester), CustomRPC.SetJester, CustomGameOptions.JesterOn));
 
                 if (Check(CustomGameOptions.SheriffOn))
                     CrewmateRoles.Add((typeof(Sheriff), CustomRPC.SetSheriff, CustomGameOptions.SheriffOn));
@@ -742,12 +738,8 @@ namespace TownOfUs
                 if (Check(CustomGameOptions.SwapperOn))
                     CrewmateRoles.Add((typeof(Swapper), CustomRPC.SetSwapper, CustomGameOptions.SwapperOn));
 
-                if (Check(CustomGameOptions.ShifterOn))
-                    NeutralRoles.Add((typeof(Shifter), CustomRPC.SetShifter, CustomGameOptions.ShifterOn));
-
                 if (Check(CustomGameOptions.InvestigatorOn))
-                    CrewmateRoles.Add((typeof(Investigator), CustomRPC.SetInvestigator,
-                        CustomGameOptions.InvestigatorOn));
+                    CrewmateRoles.Add((typeof(Investigator), CustomRPC.SetInvestigator, CustomGameOptions.InvestigatorOn));
 
                 if (Check(CustomGameOptions.TimeLordOn))
                     CrewmateRoles.Add((typeof(TimeLord), CustomRPC.SetTimeLord, CustomGameOptions.TimeLordOn));
@@ -755,24 +747,8 @@ namespace TownOfUs
                 if (Check(CustomGameOptions.MedicOn))
                     CrewmateRoles.Add((typeof(Medic), CustomRPC.SetMedic, CustomGameOptions.MedicOn));
 
-                if (Check(CustomGameOptions.GlitchOn))
-                    NeutralRoles.Add((typeof(Glitch), CustomRPC.SetGlitch, CustomGameOptions.GlitchOn));
-
                 if (Check(CustomGameOptions.SeerOn))
                     CrewmateRoles.Add((typeof(Seer), CustomRPC.SetSeer, CustomGameOptions.SeerOn));
-
-                if (Check(CustomGameOptions.TorchOn))
-                    CrewmateModifiers.Add((typeof(Torch), CustomRPC.SetTorch, CustomGameOptions.TorchOn));
-
-                if (Check(CustomGameOptions.DiseasedOn))
-                    CrewmateModifiers.Add((typeof(Diseased), CustomRPC.SetDiseased, CustomGameOptions.DiseasedOn));
-
-                if (Check(CustomGameOptions.MorphlingOn))
-                    ImpostorRoles.Add((typeof(Morphling), CustomRPC.SetMorphling, CustomGameOptions.MorphlingOn));
-
-
-                if (Check(CustomGameOptions.CamouflagerOn))
-                    ImpostorRoles.Add((typeof(Camouflager), CustomRPC.SetCamouflager, CustomGameOptions.CamouflagerOn));
 
                 if (Check(CustomGameOptions.SpyOn))
                     CrewmateRoles.Add((typeof(Spy), CustomRPC.SetSpy, CustomGameOptions.SpyOn));
@@ -780,40 +756,26 @@ namespace TownOfUs
                 if (Check(CustomGameOptions.SnitchOn))
                     CrewmateRoles.Add((typeof(Snitch), CustomRPC.SetSnitch, CustomGameOptions.SnitchOn));
 
-                if (Check(CustomGameOptions.MinerOn))
-                    ImpostorRoles.Add((typeof(Miner), CustomRPC.SetMiner, CustomGameOptions.MinerOn));
-
-                if (Check(CustomGameOptions.SwooperOn))
-                    ImpostorRoles.Add((typeof(Swooper), CustomRPC.SetSwooper, CustomGameOptions.SwooperOn));
-
-                if (Check(CustomGameOptions.TiebreakerOn))
-                    GlobalModifiers.Add((typeof(Tiebreaker), CustomRPC.SetTiebreaker, CustomGameOptions.TiebreakerOn));
-
-                if (Check(CustomGameOptions.FlashOn))
-                    GlobalModifiers.Add((typeof(Flash), CustomRPC.SetFlash, CustomGameOptions.FlashOn));
-
-                if (Check(CustomGameOptions.JanitorOn))
-                    ImpostorRoles.Add((typeof(Janitor), CustomRPC.SetJanitor, CustomGameOptions.JanitorOn));
-
-                if (Check(CustomGameOptions.DrunkOn))
-                    GlobalModifiers.Add((typeof(Drunk), CustomRPC.SetDrunk, CustomGameOptions.DrunkOn));
+                if (Check(CustomGameOptions.AltruistOn))
+                    CrewmateRoles.Add((typeof(Altruist), CustomRPC.SetAltruist, CustomGameOptions.AltruistOn));
 
                 if (Check(CustomGameOptions.ArsonistOn))
                     NeutralRoles.Add((typeof(Arsonist), CustomRPC.SetArsonist, CustomGameOptions.ArsonistOn));
 
                 if (Check(CustomGameOptions.ExecutionerOn))
                     NeutralRoles.Add((typeof(Executioner), CustomRPC.SetExecutioner, CustomGameOptions.ExecutionerOn));
+                #endregion
+                #region Neutral Roles
+                if (Check(CustomGameOptions.JesterOn))
+                    NeutralRoles.Add((typeof(Jester), CustomRPC.SetJester, CustomGameOptions.JesterOn));
 
-                if (Check(CustomGameOptions.AltruistOn))
-                    CrewmateRoles.Add((typeof(Altruist), CustomRPC.SetAltruist, CustomGameOptions.AltruistOn));
+                if (Check(CustomGameOptions.ShifterOn))
+                    NeutralRoles.Add((typeof(Shifter), CustomRPC.SetShifter, CustomGameOptions.ShifterOn));
 
-                if (Check(CustomGameOptions.BigBoiOn))
-                    GlobalModifiers.Add((typeof(BigBoiModifier), CustomRPC.SetBigBoi, CustomGameOptions.BigBoiOn));
-
-                if (Check(CustomGameOptions.ButtonBarryOn))
-                    GlobalModifiers.Add(
-                        (typeof(ButtonBarry), CustomRPC.SetButtonBarry, CustomGameOptions.ButtonBarryOn));
-
+                if (Check(CustomGameOptions.GlitchOn))
+                    NeutralRoles.Add((typeof(Glitch), CustomRPC.SetGlitch, CustomGameOptions.GlitchOn));
+                #endregion
+                #region Impostor Roles
                 if (Check(CustomGameOptions.UndertakerOn))
                     ImpostorRoles.Add((typeof(Undertaker), CustomRPC.SetUndertaker, CustomGameOptions.UndertakerOn));
 
@@ -823,7 +785,45 @@ namespace TownOfUs
                 if (Check(CustomGameOptions.UnderdogOn))
                     ImpostorRoles.Add((typeof(Underdog), CustomRPC.SetUnderdog, CustomGameOptions.UnderdogOn));
 
+                if (Check(CustomGameOptions.MorphlingOn))
+                    ImpostorRoles.Add((typeof(Morphling), CustomRPC.SetMorphling, CustomGameOptions.MorphlingOn));
 
+                if (Check(CustomGameOptions.CamouflagerOn))
+                    ImpostorRoles.Add((typeof(Camouflager), CustomRPC.SetCamouflager, CustomGameOptions.CamouflagerOn));
+
+                if (Check(CustomGameOptions.MinerOn))
+                    ImpostorRoles.Add((typeof(Miner), CustomRPC.SetMiner, CustomGameOptions.MinerOn));
+
+                if (Check(CustomGameOptions.SwooperOn))
+                    ImpostorRoles.Add((typeof(Swooper), CustomRPC.SetSwooper, CustomGameOptions.SwooperOn));
+
+                if (Check(CustomGameOptions.JanitorOn))
+                    ImpostorRoles.Add((typeof(Janitor), CustomRPC.SetJanitor, CustomGameOptions.JanitorOn));
+                #endregion
+                #region Crewmate Modifiers
+                if (Check(CustomGameOptions.TorchOn))
+                    CrewmateModifiers.Add((typeof(Torch), CustomRPC.SetTorch, CustomGameOptions.TorchOn));
+
+                if (Check(CustomGameOptions.DiseasedOn))
+                    CrewmateModifiers.Add((typeof(Diseased), CustomRPC.SetDiseased, CustomGameOptions.DiseasedOn));
+                #endregion
+                #region Global Modifiers
+                if (Check(CustomGameOptions.TiebreakerOn))
+                    GlobalModifiers.Add((typeof(Tiebreaker), CustomRPC.SetTiebreaker, CustomGameOptions.TiebreakerOn));
+
+                if (Check(CustomGameOptions.FlashOn))
+                    GlobalModifiers.Add((typeof(Flash), CustomRPC.SetFlash, CustomGameOptions.FlashOn));
+
+                if (Check(CustomGameOptions.DrunkOn))
+                    GlobalModifiers.Add((typeof(Drunk), CustomRPC.SetDrunk, CustomGameOptions.DrunkOn));
+
+                if (Check(CustomGameOptions.BigBoiOn))
+                    GlobalModifiers.Add((typeof(BigBoiModifier), CustomRPC.SetBigBoi, CustomGameOptions.BigBoiOn));
+
+                if (Check(CustomGameOptions.ButtonBarryOn))
+                    GlobalModifiers.Add(
+                        (typeof(ButtonBarry), CustomRPC.SetButtonBarry, CustomGameOptions.ButtonBarryOn));
+                #endregion
                 GenEachRole(infected.ToList());
             }
         }

--- a/source/Patches/RpcHandling.cs
+++ b/source/Patches/RpcHandling.cs
@@ -103,16 +103,6 @@ namespace TownOfUs
             crewAndNeutralRoles.AddRange(CrewmateRoles);
             SortRoles(crewAndNeutralRoles, crewmates.Count);
 
-            foreach (var (_, rpc, _) in crewAndNeutralRoles)
-            {
-                TownOfUs.LogMessage($"Enabled Crew/Neut Role: {rpc}");
-            }
-
-            foreach (var (_, rpc, _) in ImpostorRoles)
-            {
-                TownOfUs.LogMessage($"Enabled Imp Role: {rpc}");
-            }
-
             if (Check(CustomGameOptions.VanillaGame))
             {
                 CrewmateRoles.Clear();
@@ -155,9 +145,6 @@ namespace TownOfUs
                 var targets = Utils.GetCrewmates(impostors).Where(
                     crewmate => Role.GetRole(crewmate)?.Faction == Faction.Crewmates
                 ).ToList();
-                TownOfUs.LogMessage($"Executioner Targets ({targets.Count})");
-                foreach (var target in targets)
-                    TownOfUs.LogMessage(target.name);
                 if (targets.Count > 0)
                 {
                     var exec = Role.Gen<Executioner>(

--- a/source/Patches/Shuffle.cs
+++ b/source/Patches/Shuffle.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using UnityEngine;
 
 namespace TownOfUs
@@ -8,17 +8,24 @@ namespace TownOfUs
         /// <summary>
         ///     Shuffles the element order of the specified list.
         /// </summary>
-        public static void Shuffle<T>(this List<T> ts)
+        public static void Shuffle<T>(this List<T> list)
         {
-            var count = ts.Count;
+            var count = list.Count;
             var last = count - 1;
             for (var i = 0; i < last; ++i)
             {
                 var r = Random.Range(i, count);
-                var tmp = ts[i];
-                ts[i] = ts[r];
-                ts[r] = tmp;
+                var tmp = list[i];
+                list[i] = list[r];
+                list[r] = tmp;
             }
+        }
+
+        public static T TakeFirst<T>(this List<T> list)
+        {
+            var item = list[0];
+            list.RemoveAt(0);
+            return item;
         }
     }
 }

--- a/source/Patches/Utils.cs
+++ b/source/Patches/Utils.cs
@@ -167,6 +167,23 @@ namespace TownOfUs
             return Role.GetRole(player)?.Faction == faction;
         }
 
+        public static List<PlayerControl> GetCrewmates(List<PlayerControl> impostors)
+        {
+            return PlayerControl.AllPlayerControls.ToArray().Where(
+                player => !impostors.Any(imp => imp.PlayerId == player.PlayerId)
+            ).ToList();
+        }
+
+        public static List<PlayerControl> GetImpostors(
+            List<GameData.PlayerInfo> infected)
+        {
+            var impostors = new List<PlayerControl>();
+            foreach (var impData in infected)
+                impostors.Add(impData.Object);
+
+            return impostors;
+        }
+
         public static RoleEnum GetRole(PlayerControl player)
         {
             if (player == null) return RoleEnum.None;
@@ -187,22 +204,6 @@ namespace TownOfUs
             return null;
         }
 
-        public static List<PlayerControl> getCrewmates(IEnumerable<GameData.PlayerInfo> infection)
-        {
-            var list = new List<PlayerControl>();
-            foreach (var player in PlayerControl.AllPlayerControls)
-            {
-                var isImpostor = false;
-                foreach (var impostor in infection)
-                    if (player.PlayerId == impostor.Object.PlayerId)
-                        isImpostor = true;
-
-                if (!isImpostor) list.Add(player);
-            }
-
-            return list;
-        }
-
         public static bool isShielded(this PlayerControl player)
         {
             return Role.GetRoles(RoleEnum.Medic).Any(role =>
@@ -219,22 +220,6 @@ namespace TownOfUs
                 var shieldedPlayer = ((Medic)role).ShieldedPlayer;
                 return shieldedPlayer != null && player.PlayerId == shieldedPlayer.PlayerId;
             }) as Medic;
-        }
-
-        public static List<PlayerControl> getImpostors(IEnumerable<GameData.PlayerInfo> infection)
-        {
-            var list = new List<PlayerControl>();
-            foreach (var player in PlayerControl.AllPlayerControls)
-            {
-                var isImpostor = false;
-                foreach (var impostor in infection)
-                    if (player.PlayerId == impostor.Object.PlayerId)
-                        isImpostor = true;
-
-                if (isImpostor) list.Add(player);
-            }
-
-            return list;
         }
 
         public static PlayerControl getClosestPlayer(PlayerControl refPlayer, List<PlayerControl> AllPlayers)

--- a/source/TownOfUs.cs
+++ b/source/TownOfUs.cs
@@ -62,6 +62,8 @@ namespace TownOfUs
         public ConfigEntry<ushort> Port { get; set; }
         //public static Sprite BirthdayVoteSprite;
 
+        public static void LogMessage(object message) =>
+            PluginSingleton<TownOfUs>.Instance.Log.LogMessage(message);
 
         public override void Load()
         {


### PR DESCRIPTION
This PR modifies the role generation to fix a couple bugs, namely

executioner spawning without a target

executioner attempting to generate and failing because there is no target (this has been changed to just make the exec a crewmate, and anyway it would require a game with all neutrals, which doesn't work anyway)