### PR TITLE
fix: clean up role generation

### DIFF
--- a/source/Patches/RpcHandling.cs
+++ b/source/Patches/RpcHandling.cs
@@ -131,8 +131,12 @@ namespace TownOfUs
             if (LoversOn)
                 Lover.Gen(crewmates, impostors);
 
-            foreach (var (type, rpc, _) in ImpostorRoles)
+            foreach (var player in impostors)
+            {
+                var (type, rpc, _) = ImpostorRoles.TakeFirst();
+                if (type == null) break;
                 Role.Gen<Role>(type, impostors, rpc);
+            }
 
             foreach (var crewmate in crewmates)
                 Role.Gen<Role>(typeof(Crewmate), crewmate, CustomRPC.SetCrewmate);
@@ -167,8 +171,11 @@ namespace TownOfUs
             var canHaveModifier = PlayerControl.AllPlayerControls.ToArray().ToList();
             canHaveModifier.Shuffle();
 
-            foreach (var (type, rpc, _) in GlobalModifiers)
+            foreach (var player in canHaveModifier) {
+                var (type, rpc, _) = GlobalModifiers.TakeFirst();
+                if (type == null) break;
                 Role.Gen<Modifier>(type, canHaveModifier, rpc);
+            }
 
             canHaveModifier.RemoveAll(player => !player.Data.IsImpostor);
             canHaveModifier.Shuffle();
@@ -176,6 +183,7 @@ namespace TownOfUs
             foreach (var player in canHaveModifier)
             {
                 var (type, rpc, _) = CrewmateModifiers.TakeFirst();
+                if (type == null) break;
                 Role.Gen<Modifier>(type, player, rpc);
             }
 

--- a/source/Patches/RpcHandling.cs
+++ b/source/Patches/RpcHandling.cs
@@ -131,11 +131,11 @@ namespace TownOfUs
             if (LoversOn)
                 Lover.Gen(crewmates, impostors);
 
-            foreach (var player in impostors)
+            while (impostors.Count > 0)
             {
                 var (type, rpc, _) = ImpostorRoles.TakeFirst();
                 if (type == null) break;
-                Role.Gen<Role>(type, impostors, rpc);
+                Role.Gen<Role>(type, impostors.TakeFirst(), rpc);
             }
 
             foreach (var crewmate in crewmates)
@@ -171,27 +171,22 @@ namespace TownOfUs
             var canHaveModifier = PlayerControl.AllPlayerControls.ToArray().ToList();
             canHaveModifier.Shuffle();
 
-            foreach (var player in canHaveModifier) {
-                var (type, rpc, _) = GlobalModifiers.TakeFirst();
-                if (type == null) break;
+            foreach (var (type, rpc, _) in GlobalModifiers)
                 Role.Gen<Modifier>(type, canHaveModifier, rpc);
-            }
 
             canHaveModifier.RemoveAll(player => !player.Data.IsImpostor);
             canHaveModifier.Shuffle();
 
-            foreach (var player in canHaveModifier)
+            while (canHaveModifier.Count > 0)
             {
                 var (type, rpc, _) = CrewmateModifiers.TakeFirst();
-                if (type == null) break;
-                Role.Gen<Modifier>(type, player, rpc);
+                Role.Gen<Modifier>(type, canHaveModifier.TakeFirst(), rpc);
             }
 
             if (PhantomOn)
             {
-                var vanilla = PlayerControl.AllPlayerControls.ToArray().Where(x => x.Is(RoleEnum.Crewmate)).ToList();
-                var toChooseFrom = vanilla.Any()
-                    ? vanilla
+                var toChooseFrom = crewmates.Count > 0
+                    ? crewmates
                     : PlayerControl.AllPlayerControls.ToArray().Where(x => x.Is(Faction.Crewmates) && !x.isLover())
                         .ToList();
                 var rand = Random.RandomRangeInt(0, toChooseFrom.Count);

--- a/source/Patches/Shuffle.cs
+++ b/source/Patches/Shuffle.cs
@@ -23,6 +23,7 @@ namespace TownOfUs
 
         public static T TakeFirst<T>(this List<T> list)
         {
+            if (list.Count == 0) return default;
             var item = list[0];
             list.RemoveAt(0);
             return item;


### PR DESCRIPTION
this PR fixes a small bug i introduced with the previous PR - when a loving impostor is generated the game would error