### PR TITLE
fix(Undertaker): pause kcd when dragging

### DIFF
--- a/source/Patches/ImpostorRoles/UndertakerMod/PatchKillTimer.cs
+++ b/source/Patches/ImpostorRoles/UndertakerMod/PatchKillTimer.cs
@@ -1,0 +1,16 @@
+using HarmonyLib;
+using TownOfUs.Roles;
+using UnityEngine;
+
+namespace TownOfUs.ImpostorRoles.UndertakerMod
+{
+    [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.SetKillTimer))]
+    public static class PatchKillTimer
+    {
+        public static bool Prefix(PlayerControl __instance)
+        {
+            var role = Role.GetRole(__instance);
+            return role?.RoleType != RoleEnum.Undertaker || ((Undertaker)role).CurrentlyDragging == null;
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes the undertaker to pause its cooldown when dragging a body (as was originally intended for the role)