### PR TITLE
chore(csproj): add post-build action

### DIFF
--- a/source/TownOfUs.csproj
+++ b/source/TownOfUs.csproj
@@ -20,4 +20,8 @@
     <EmbeddedResource Include="Resources\*" />
     <EmbeddedResource Include="Resources\Hats\**\*.png" />
   </ItemGroup>
+   
+  <Target Name="Copy" AfterTargets="Build">
+    <Copy SourceFiles="$(OutputPath)$(AssemblyName).dll" DestinationFolder="../AmongUs/BepInEx/plugins/" />
+  </Target>
 </Project>


### PR DESCRIPTION
the 2.2.0 release removed the post-build action in the csproj that moved the DLL to the AmongUs folder, this PR reverts that removal