### PR TITLE
Allow shifting into Glitch

### DIFF
--- a/source/Patches/NeutralRoles/ShifterMod/PerformKillButton.cs
+++ b/source/Patches/NeutralRoles/ShifterMod/PerformKillButton.cs
@@ -127,6 +127,7 @@ namespace TownOfUs.NeutralRoles.ShifterMod
                 case RoleEnum.Arsonist:
                 case RoleEnum.Crewmate:
                 case RoleEnum.Altruist:
+                case RoleEnum.Glitch:
 
                     if (role == RoleEnum.Investigator) Footprint.DestroyAll(Role.GetRole<Investigator>(other));
 
@@ -207,7 +208,6 @@ namespace TownOfUs.NeutralRoles.ShifterMod
                 case RoleEnum.Janitor:
                 case RoleEnum.LoverImpostor:
                 case RoleEnum.Impostor:
-                case RoleEnum.Glitch:
                 case RoleEnum.Shifter:
                     shifter.Data.IsImpostor = true;
                     shifter.MurderPlayer(shifter);


### PR DESCRIPTION
This might be a contentious one. I recognize that Glitch is kind of like an impostor because they have an unrestricted kill button. Their goal, like impostors and unlike other neutral roles, is to kill all the other players. However, they're a neutral role. So as defined, the Shifter should be able to shift into them.

If you don't want to make this change, we should change the README and rename the setting to indicate that it's non-killer instead of non-impostor.