### PR TITLE
Sheriff should be able to kill all neutral roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,9 @@ However, if they kill a Crewmate or a Neutral player they can't kill, they inste
 | Show Sheriff | Whether everybody can see who the Sheriff is | Toggle | False |
 | Sheriff Miskill Kills Crewmate | Whether the other player is killed if the Sheriff Misfires | Toggle | False |
 | Sheriff Kills Jester | Whether the Sheriff is able to kill the Jester | Toggle | False |
+| Sheriff Kills Shifter | Whether the Sheriff is able to kill the Shifter | Toggle | False |
 | Sheriff Kills The Glitch | Whether the Sheriff is able to kill The Glitch | Toggle | False |
+| Sheriff Kills the Executioner | Whether the Sheriff is able to kill the Executioner | Toggle | False |
 | Sheriff Kills Arsonist | Whether the Sheriff is able to kill the Arsonist | Toggle | False |
 | Sheriff Kill Cooldown | The cooldown on the Sheriff's kill button | Time | 25s |
 | Sheriff can report who they've killed | Whether the Sheriff is able to report their own kills | Toggle | True |

--- a/source/Patches/CrewmateRoles/SheriffMod/Kill.cs
+++ b/source/Patches/CrewmateRoles/SheriffMod/Kill.cs
@@ -42,8 +42,11 @@ namespace TownOfUs.CrewmateRoles.SheriffMod
 
             var flag4 = role.ClosestPlayer.Data.IsImpostor ||
                         role.ClosestPlayer.Is(RoleEnum.Jester) && CustomGameOptions.SheriffKillsJester ||
+                        role.ClosestPlayer.Is(RoleEnum.Shifter) && CustomGameOptions.SheriffKillsShifter ||
                         role.ClosestPlayer.Is(RoleEnum.Glitch) && CustomGameOptions.SheriffKillsGlitch ||
-                        role.ClosestPlayer.Is(RoleEnum.Arsonist) && CustomGameOptions.SheriffKillsArsonist;
+                        role.ClosestPlayer.Is(RoleEnum.Executioner) && CustomGameOptions.SheriffKillsExecutioner ||
+                        role.ClosestPlayer.Is(RoleEnum.Arsonist) && CustomGameOptions.SheriffKillsArsonist
+                ;
             if (!flag4)
             {
                 if (CustomGameOptions.SheriffKillOther)

--- a/source/Patches/CustomGameOptions.cs
+++ b/source/Patches/CustomGameOptions.cs
@@ -47,7 +47,9 @@ namespace TownOfUs
         public static bool ShowSheriff => Generate.ShowSheriff.Get();
         public static bool SheriffKillOther => Generate.SheriffKillOther.Get();
         public static bool SheriffKillsJester => Generate.SheriffKillsJester.Get();
+        public static bool SheriffKillsShifter => Generate.SheriffKillsShifter.Get();
         public static bool SheriffKillsGlitch => Generate.SheriffKillsGlitch.Get();
+        public static bool SheriffKillsExecutioner => Generate.SheriffKillsExecutioner.Get();
         public static bool SheriffKillsArsonist => Generate.SheriffKillsArsonist.Get();
         public static float SheriffKillCd => Generate.SheriffKillCd.Get();
         public static int MayorVoteBank => (int) Generate.MayorVoteBank.Get();

--- a/source/Patches/CustomOption/Generate.cs
+++ b/source/Patches/CustomOption/Generate.cs
@@ -74,7 +74,9 @@ namespace TownOfUs.CustomOption
         public static CustomToggleOption ShowSheriff;
         public static CustomToggleOption SheriffKillOther;
         public static CustomToggleOption SheriffKillsJester;
+        public static CustomToggleOption SheriffKillsShifter;
         public static CustomToggleOption SheriffKillsGlitch;
+        public static CustomToggleOption SheriffKillsExecutioner;
         public static CustomToggleOption SheriffKillsArsonist;
         public static CustomNumberOption SheriffKillCd;
         public static CustomToggleOption SheriffBodyReport;
@@ -294,8 +296,12 @@ namespace TownOfUs.CustomOption
 
             SheriffKillsJester =
                 new CustomToggleOption(num++, "Sheriff Kills Jester", false);
+            SheriffKillsShifter =
+                new CustomToggleOption(num++, "Sheriff Kills Shifter", false);
             SheriffKillsGlitch =
                 new CustomToggleOption(num++, "Sheriff Kills The Glitch", false);
+            SheriffKillsExecutioner =
+                new CustomToggleOption(num++, "Sheriff Kills Executioner", false);
             SheriffKillsArsonist =
                 new CustomToggleOption(num++, "Sheriff Kills Arsonist", false);
 


### PR DESCRIPTION
Added options to allow the shifter to optionally be able to kill the other two neutral roles (Shifter and Executioner) for completeness.